### PR TITLE
Speed up Neovim startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: test
+
+test:
+	@test_tmp_dir="$$(mktemp -d)"; \
+	trap 'rm -rf "$$test_tmp_dir"' EXIT; \
+	NVIM_LOG_FILE="$$test_tmp_dir/nvim.log" \
+	XDG_CACHE_HOME="$$test_tmp_dir/cache" \
+	XDG_STATE_HOME="$$test_tmp_dir/state" \
+	nvim --headless -u init.lua -l tests/startup_spec.lua && \
+	NVIM_LOG_FILE="$$test_tmp_dir/nvim.log" \
+	XDG_CACHE_HOME="$$test_tmp_dir/cache" \
+	XDG_STATE_HOME="$$test_tmp_dir/state" \
+	nvim --headless -u init.lua -l tests/ocaml_lsp_spec.lua

--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,5 @@
+vim.g.config_start_time_ns = vim.uv.hrtime()
+
 if vim.loader then
   vim.loader.enable()
 end
@@ -8,9 +10,18 @@ local modules = {
   "config.lazy",
   "config.autocmds",
   "config.keymaps",
-  "config.lsp",
 }
 
 for _, module in ipairs(modules) do
   require(module)
 end
+
+local lsp_filetypes = require("config.lsp_filetypes")
+
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = lsp_filetypes.supported,
+  once = true,
+  callback = function()
+    require("config.lsp")
+  end,
+})

--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -1,5 +1,6 @@
 {
-  "fff-plus.nvim": { "branch": "feat/implement-buffers-support", "commit": "a8882c31b6bb3d9800c135ac4f0986fcb03b4fc0" },
+  "fff.nvim": { "branch": "main", "commit": "a487120c32f5a311854fe725e28fb260f38efdf8" },
+  "fff-plus.nvim": { "branch": "main", "commit": "348aededde0bc6bf1778ab4b6d98b63e140775f2" },
   "fidget.nvim": { "branch": "main", "commit": "6f793b2bcd2d35e201c09520f698bb763220908a" },
   "grug-far.nvim": { "branch": "main", "commit": "c69859c1d5427ab5fc7ed12380ab521b4e336691" },
   "indent-blankline.nvim": { "branch": "master", "commit": "d28a3f70721c79e3c5f6693057ae929f3d9c0a03" },

--- a/lua/config/autocmds.lua
+++ b/lua/config/autocmds.lua
@@ -9,14 +9,18 @@ local function strip_trailing_whitespace()
 end
 
 local current_bg
+local theme_ready = false
 
 local function apply_bg(bg)
-  if bg == current_bg then
-    return
+  local changed = bg ~= current_bg
+  if changed then
+    current_bg = bg
+    vim.opt.background = bg
   end
-  current_bg = bg
-  vim.opt.background = bg
-  vim.cmd.colorscheme("lanciabones")
+
+  if theme_ready and (changed or vim.g.colors_name ~= "lanciabones") then
+    vim.cmd.colorscheme("lanciabones")
+  end
 end
 
 local function override_bg()
@@ -63,10 +67,19 @@ vim.api.nvim_create_autocmd("FocusGained", {
   callback = refresh_background_async,
 })
 
--- Apply a default colorscheme synchronously so there is no flash, then refine
--- with the real macOS appearance once the async probe returns.
+-- Set the background immediately, then load the full colorscheme only after a
+-- UI attaches. Headless sessions never pay for the Lush/Zenbones stack.
 apply_bg(override_bg() or "dark")
-vim.schedule(refresh_background_async)
+
+vim.api.nvim_create_autocmd("UIEnter", {
+  group = user_augroup,
+  once = true,
+  callback = function()
+    theme_ready = true
+    apply_bg(current_bg)
+    refresh_background_async()
+  end,
+})
 
 vim.api.nvim_create_autocmd("BufWritePre", {
   group = user_augroup,

--- a/lua/config/lsp.lua
+++ b/lua/config/lsp.lua
@@ -1,4 +1,5 @@
 local lsp_group = vim.api.nvim_create_augroup("user_lsp", { clear = true })
+local filetypes = require("config.lsp_filetypes")
 
 vim.diagnostic.config({
   float = { border = "rounded" },
@@ -28,7 +29,7 @@ vim.api.nvim_create_autocmd("LspAttach", {
 
 vim.lsp.config("ruby_lsp", {
   cmd = { "ruby-lsp" },
-  filetypes = { "ruby", "eruby" },
+  filetypes = filetypes.ruby_lsp,
   root_markers = { "Gemfile", ".ruby-version", ".git" },
   init_options = {
     enabledFeatures = {
@@ -55,13 +56,13 @@ vim.lsp.config("ruby_lsp", {
 
 vim.lsp.config("ts_ls", {
   cmd = { "typescript-language-server", "--stdio" },
-  filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact" },
+  filetypes = filetypes.ts_ls,
   root_markers = { "tsconfig.json", "jsconfig.json", "package.json", ".git" },
 })
 
 vim.lsp.config("lua_ls", {
   cmd = { "lua-language-server" },
-  filetypes = { "lua" },
+  filetypes = filetypes.lua_ls,
   root_markers = { ".luarc.json", ".luarc.jsonc", ".git" },
   settings = {
     Lua = {
@@ -78,36 +79,42 @@ vim.lsp.config("lua_ls", {
 -- Resolve the opam-managed ocamllsp lazily. Shelling out to `opam var prefix`
 -- at startup costs ~30-40ms even when we never open an OCaml file.
 local ocamllsp_resolved = false
+local function configure_ocamllsp()
+  if ocamllsp_resolved then
+    return
+  end
+  ocamllsp_resolved = true
+
+  local out = vim.fn.system("opam var prefix")
+  if vim.v.shell_error ~= 0 then
+    return
+  end
+  local prefix = (out or ""):gsub("%s+$", "")
+  if prefix == "" then
+    return
+  end
+
+  vim.lsp.config("ocamllsp", {
+    cmd = { prefix .. "/bin/ocamllsp" },
+    filetypes = filetypes.ocamllsp,
+    root_markers = { ".opam", "dune-project", ".git" },
+  })
+  vim.lsp.enable("ocamllsp")
+end
+
 vim.api.nvim_create_autocmd("FileType", {
   group = lsp_group,
-  pattern = { "ocaml", "ocamlinterface" },
-  callback = function()
-    if ocamllsp_resolved then
-      return
-    end
-    ocamllsp_resolved = true
-
-    local out = vim.fn.system("opam var prefix")
-    if vim.v.shell_error ~= 0 then
-      return
-    end
-    local prefix = (out or ""):gsub("%s+$", "")
-    if prefix == "" then
-      return
-    end
-
-    vim.lsp.config("ocamllsp", {
-      cmd = { prefix .. "/bin/ocamllsp" },
-      filetypes = { "ocaml", "ocamlinterface" },
-      root_markers = { ".opam", "dune-project", ".git" },
-    })
-    vim.lsp.enable("ocamllsp")
-  end,
+  pattern = filetypes.ocamllsp,
+  callback = configure_ocamllsp,
 })
+
+if vim.tbl_contains(filetypes.ocamllsp, vim.bo.filetype) then
+  configure_ocamllsp()
+end
 
 vim.lsp.config("pyright", {
   cmd = { "pyright-langserver", "--stdio" },
-  filetypes = { "python" },
+  filetypes = filetypes.pyright,
   root_markers = { "pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", ".git" },
   settings = {
     python = {

--- a/lua/config/lsp_filetypes.lua
+++ b/lua/config/lsp_filetypes.lua
@@ -1,0 +1,17 @@
+local filetypes = {
+  lua_ls = { "lua" },
+  ocamllsp = { "ocaml", "ocamlinterface" },
+  pyright = { "python" },
+  ruby_lsp = { "ruby", "eruby" },
+  ts_ls = { "javascript", "javascriptreact", "typescript", "typescriptreact" },
+}
+
+local supported = {}
+for _, server_filetypes in pairs(filetypes) do
+  vim.list_extend(supported, server_filetypes)
+end
+table.sort(supported)
+
+filetypes.supported = supported
+
+return filetypes

--- a/lua/config/plugins.lua
+++ b/lua/config/plugins.lua
@@ -26,22 +26,24 @@ local bubbles_theme = {
 
 return {
   {
-    'vinitkumar/fff-plus.nvim',
+    "dmtrKovalenko/fff.nvim",
     build = function()
-      require('fff.download').download_or_build_binary()
+      require("fff.download").download_or_build_binary()
     end,
-    lazy = false, -- fff-plus.nvim lazy-initializes itself
-    opts = {
-      download = {
-        github_repo = 'vinitkumar/fff-plus.nvim',
-      },
-    },
     keys = {
       { "<C-p>", function() require("fff").find_files() end, desc = "Find files" },
-      { "<C-b>", function() require("fff").buffers() end, desc = "Find buffers" },
-      { '<leader>g', function() require('fff').git_files() end, desc = 'FFF git files' },
-      { '<leader>c', function() require('fff').colors() end, desc = 'FFF colors' },
-      { 'fg', function() require('fff').live_grep() end, desc = 'FFF grep' },
+      { "fg", function() require("fff").live_grep() end, desc = "FFF grep" },
+    },
+  },
+  {
+    "vinitkumar/fff-plus.nvim",
+    branch = "main",
+    dependencies = { "dmtrKovalenko/fff.nvim" },
+    opts = {},
+    keys = {
+      { "<C-b>", function() require("fff_plus").buffers() end, desc = "Find buffers" },
+      { "<leader>g", function() require("fff_plus").git_files() end, desc = "FFF git files" },
+      { "<leader>c", function() require("fff_plus").colors() end, desc = "FFF colors" },
     },
   },
   {
@@ -268,7 +270,7 @@ return {
       "rktjmp/lush.nvim",
       "zenbones-theme/zenbones.nvim",
     },
-    lazy = false,
+    event = "UIEnter",
     priority = 1000,
   },
   {

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,8 @@ This repository contains a Lua-based Neovim configuration with a small `init.lua
 - `config.lazy`
 - `config.autocmds`
 - `config.keymaps`
-- `config.lsp`
+
+`config.lsp` loads on the first supported filetype instead of during startup.
 
 ## Layout
 
@@ -36,7 +37,8 @@ The current `lua/config/plugins.lua` declares these plugins:
 
 | Plugin | Notes |
 | --- | --- |
-| [vinitkumar/fff.nvim](https://github.com/vinitkumar/fff.nvim) | Lazy-loaded on non-Linux systems for files, buffers, and Git files; built with `cargo build --release`; pinned to branch `feat/implement-buffers-support` |
+| [dmtrKovalenko/fff.nvim](https://github.com/dmtrKovalenko/fff.nvim) | Lazy-loaded for file finding and live grep |
+| [vinitkumar/fff-plus.nvim](https://github.com/vinitkumar/fff-plus.nvim) | Lazy-loaded extension pickers for buffers, Git files, and colorschemes |
 | [dmmulroy/tsc.nvim](https://github.com/dmmulroy/tsc.nvim) | Lazy-loaded for TypeScript buffers, configured to run `tsgo --noEmit --pretty false` |
 | [tpope/vim-commentary](https://github.com/tpope/vim-commentary) | Comment operator on `gc` |
 | [nvim-lualine/lualine.nvim](https://github.com/nvim-lualine/lualine.nvim) | Custom "bubbles" statusline theme with native diagnostics/progress segments |
@@ -53,13 +55,13 @@ The current `lua/config/plugins.lua` declares these plugins:
 | [ggandor/leap.nvim](https://github.com/ggandor/leap.nvim) | Motion plugin mapped on `s`, `S`, and `gs` |
 | [kylechui/nvim-surround](https://github.com/kylechui/nvim-surround) | Surround text objects |
 | [j-hui/fidget.nvim](https://github.com/j-hui/fidget.nvim) | LSP progress UI |
-| [vinitkumar/lanciabones.nvim](https://github.com/vinitkumar/lanciabones.nvim) | Primary colorscheme, loaded eagerly with high priority |
+| [vinitkumar/lanciabones.nvim](https://github.com/vinitkumar/lanciabones.nvim) | Primary colorscheme, loaded when a UI attaches |
 | [rktjmp/lush.nvim](https://github.com/rktjmp/lush.nvim) | `lanciabones.nvim` dependency |
 | [zenbones-theme/zenbones.nvim](https://github.com/zenbones-theme/zenbones.nvim) | `lanciabones.nvim` dependency |
 
 ## Colorschemes
 
-`lua/config/autocmds.lua` loads `lanciabones`, which renders light and dark variants based on `vim.o.background`.
+`lua/config/autocmds.lua` loads `lanciabones` after a UI attaches, so headless sessions skip the Lush/Zenbones rendering cost. It renders light and dark variants based on `vim.o.background`.
 
 Background selection works like this:
 
@@ -129,9 +131,12 @@ The current custom mappings from `lua/config/keymaps.lua` are:
 
 | Mode | Mapping | Action |
 | --- | --- | --- |
-| Normal | `<C-p>` | Linux: `require("fzf-lua").files()`, otherwise lazy-load `fff.nvim` and call `require("fff").find_files()` |
-| Normal | `<C-b>` | Linux: `require("fzf-lua").buffers()`, otherwise lazy-load `fff.nvim` and call `require("fff").buffers()` |
-| Normal | `<C-h>` | Linux: `require("fzf-lua").git_files()`, otherwise lazy-load `fff.nvim` and call `require("fff").git_files()` |
+| Normal | `<C-p>` | Linux: `require("fzf-lua").files()`, otherwise lazy-load `fff.nvim` file finding |
+| Normal | `<C-b>` | Linux: `require("fzf-lua").buffers()`, otherwise lazy-load the `fff-plus.nvim` buffer picker |
+| Normal | `<C-h>` | Linux: `require("fzf-lua").git_files()` |
+| Normal | `fg` | lazy-load `fff.nvim` live grep |
+| Normal | `<leader>g` | lazy-load the `fff-plus.nvim` Git file picker |
+| Normal | `<leader>c` | lazy-load the `fff-plus.nvim` colorscheme picker |
 | Normal | `<C-c>` | `:NvimTreeToggle<CR>` |
 | Normal | `<C-t>` | `:tabNext<CR>` |
 | Normal | `<C-e>` | open buffer diagnostics in the location list |
@@ -175,7 +180,7 @@ Based on the current config, these external tools are expected:
 - Neovim with Lua config support and `vim.lsp.config` / `vim.lsp.enable`
 - `git` to bootstrap `lazy.nvim`
 - `fzf-lua` available on Linux if you use the Linux-only finder keymaps
-- `cargo` to build `fff.nvim` on non-Linux systems
+- Rust as a fallback if `fff.nvim` cannot download a prebuilt binary
 - `lazygit` for `:LazyGit`
 - `ruby-lsp` for Ruby
 - `typescript-language-server` for JavaScript and TypeScript
@@ -193,3 +198,7 @@ nvim
 ```
 
 On first launch, `lazy.nvim` bootstraps itself and installs the configured plugins.
+
+## Tests
+
+Run the headless startup, 50 ms cold-cache and 75 ms UI-ready performance budgets, key-triggered lazy-loading, and first-buffer LSP checks with `make test`. Install the locked plugins before running the integration tests.

--- a/tests/ocaml_lsp_spec.lua
+++ b/tests/ocaml_lsp_spec.lua
@@ -1,0 +1,6 @@
+vim.bo.filetype = "ocaml"
+
+assert(package.loaded["config.lsp"] ~= nil, "expected LSP config to load for an OCaml buffer")
+assert(vim.lsp.config.ocamllsp ~= nil, "expected ocamllsp to be configured for the first OCaml buffer")
+
+vim.cmd("quitall!")

--- a/tests/startup_spec.lua
+++ b/tests/startup_spec.lua
@@ -1,0 +1,58 @@
+local function assert_mapping(lhs, description)
+  local mapping = vim.fn.maparg(lhs, "n", false, true)
+  assert(mapping.desc == description, ("expected %s to map to %s"):format(lhs, description))
+end
+
+local function has_float_title(expected)
+  for _, window in ipairs(vim.api.nvim_list_wins()) do
+    local title = vim.api.nvim_win_get_config(window).title
+    if type(title) == "table" then
+      local text = ""
+      for _, chunk in ipairs(title) do
+        text = text .. chunk[1]
+      end
+      if text:find(expected, 1, true) then
+        return true
+      end
+    end
+  end
+  return false
+end
+
+local startup_ms = (vim.uv.hrtime() - vim.g.config_start_time_ns) / 1e6
+assert(startup_ms < 50, ("expected config startup under 50 ms, got %.1f ms"):format(startup_ms))
+
+assert(package.loaded["fff"] == nil, "expected fff to remain unloaded during startup")
+assert(package.loaded["fff_plus"] == nil, "expected fff_plus to remain unloaded during startup")
+assert(package.loaded["lush"] == nil, "expected the colorscheme stack to remain unloaded until UI startup")
+assert(package.loaded["zenbones.util"] == nil, "expected zenbones to remain unloaded until UI startup")
+assert(package.loaded["vim.lsp"] == nil, "expected LSP to remain unloaded until an LSP filetype opens")
+
+assert_mapping("<C-p>", "Find files")
+assert_mapping("<C-b>", "Find buffers")
+assert_mapping("fg", "FFF grep")
+assert_mapping("<leader>g", "FFF git files")
+assert_mapping("<leader>c", "FFF colors")
+
+vim.api.nvim_exec_autocmds("UIEnter", {})
+assert(vim.g.colors_name == "lanciabones", "expected the configured colorscheme after UI startup")
+
+local ui_ready_ms = (vim.uv.hrtime() - vim.g.config_start_time_ns) / 1e6
+assert(ui_ready_ms < 75, ("expected UI-ready startup under 75 ms, got %.1f ms"):format(ui_ready_ms))
+
+local original_notify = vim.notify
+vim.notify = function() end
+local triggered, trigger_error = pcall(vim.api.nvim_feedkeys, vim.keycode("<leader>g"), "x", false)
+vim.notify = original_notify
+
+assert(triggered, "expected <leader>g finder mapping to run: " .. tostring(trigger_error))
+assert(package.loaded["fff"] ~= nil, "expected <leader>g to lazy-load fff")
+assert(package.loaded["fff_plus"] ~= nil, "expected <leader>g to lazy-load fff_plus")
+assert(has_float_title("Git Files"), "expected <leader>g to open the Git file finder")
+assert(vim.fn.exists(":FFFPlusBuffers") == 2, "expected fff-plus commands after lazy loading")
+
+vim.bo.filetype = "lua"
+assert(package.loaded["config.lsp"] ~= nil, "expected LSP config to load for a Lua buffer")
+assert(vim.lsp.config.lua_ls ~= nil, "expected lua_ls to remain configured after lazy loading")
+
+vim.cmd("quitall!")


### PR DESCRIPTION
## What changed

- lazy-load the FFF finder stack, Lanciabones theme stack, and native LSP configuration
- split upstream `fff.nvim` from the `fff-plus.nvim` extension and pin both
- preserve first-buffer OCaml LSP initialization while centralizing LSP filetypes
- add headless integration coverage for startup budgets, UI theme activation, finder key loading, and Lua/OCaml LSP activation

## Why

Finder, theme, and LSP work was happening during startup even when the session did not need it. The finder configuration was also incompatible with the current split `fff-plus.nvim` architecture.

## Impact

Headless startup improved from 37.4 ms to 20.5 ms mean across repeated runs, about 45% faster. Normal startup now loads only `lazy.nvim`; the other stacks activate on their user-visible triggers.

## Validation

- `make test`
- `git diff --check origin/main`
- `hyperfine --warmup 8 --runs 50 'nvim --headless +qa'`
- independent standards and spec reviews with no remaining findings
