### PR TITLE
chore: align config with Neovim 0.12

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -19,7 +19,6 @@
   "promise-async": { "branch": "main", "commit": "119e8961014c9bfaf1487bf3c2a393d254f337e2" },
   "trouble.nvim": { "branch": "main", "commit": "bd67efe408d4816e25e8491cc5ad4088e708a69a" },
   "tsc.nvim": { "branch": "main", "commit": "e083bcf1e54bc3af7df92b33235efb334e8c782c" },
-  "vim-commentary": { "branch": "master", "commit": "64a654ef4a20db1727938338310209b6a63f60c9" },
   "vimwiki": { "branch": "dev", "commit": "a54a3002e229c4b43d69ced170ff77663a5b2c40" },
   "zenbones.nvim": { "branch": "main", "commit": "8304d8df9b823ff11e103afa62f38c39f534abe6" }
 }

--- a/lua/config/autocmds.lua
+++ b/lua/config/autocmds.lua
@@ -136,22 +136,6 @@ vim.api.nvim_create_autocmd("FileType", {
   end,
 })
 
-vim.api.nvim_create_autocmd({ "BufNewFile", "BufReadPost" }, {
-  group = user_augroup,
-  pattern = "*.tsx",
-  callback = function()
-    vim.bo.filetype = "typescript.tsx"
-  end,
-})
-
-vim.api.nvim_create_autocmd({ "BufNewFile", "BufReadPost" }, {
-  group = user_augroup,
-  pattern = { "*.yaml", "*.yml" },
-  callback = function()
-    vim.bo.filetype = "yaml"
-  end,
-})
-
 vim.api.nvim_create_autocmd("FileType", {
   group = user_augroup,
   pattern = "yaml",

--- a/lua/config/keymaps.lua
+++ b/lua/config/keymaps.lua
@@ -1,13 +1,5 @@
 local keymap = vim.keymap
 
--- The macOS finder bindings (<C-p>, <C-b>, <C-h>) for fff.nvim are registered
--- lazily in config.plugins so they don't drag the plugin in at startup.
-if vim.uv.os_uname().sysname == "Linux" then
-  keymap.set("n", "<C-p>", function() require("fzf-lua").files() end, { desc = "Find files" })
-  keymap.set("n", "<C-b>", function() require("fzf-lua").buffers() end, { desc = "Find buffers" })
-  keymap.set("n", "<C-h>", function() require("fzf-lua").git_files() end, { desc = "Find Git files" })
-end
-
 keymap.set("n", "<C-c>", ":NvimTreeToggle<CR>")
 keymap.set("n", "<C-t>", ":tabNext<CR>")
 keymap.set("n", "<C-e>", function() vim.diagnostic.setloclist({ open = true }) end, { desc = "Buffer diagnostics" })
@@ -22,10 +14,8 @@ keymap.set("n", "<leader>t", ":<C-u>tabnew<CR>")
 keymap.set("n", "<leader>dt", 'i<C-r>=strftime("%c")<CR>', { noremap = true, silent = true })
 keymap.set("n", "<leader>lw", function() vim.diagnostic.setqflist() end, { desc = "Workspace diagnostics" })
 keymap.set("n", "<leader>lr", function() vim.cmd("LspRestart") end, { desc = "Restart LSP" })
-keymap.set("n", "grx", function() vim.lsp.codelens.run() end, { desc = "Run code lens" })
 keymap.set("n", "<leader>rn", function() vim.lsp.buf.rename() end, { desc = "Rename symbol" })
 keymap.set("n", "<leader>ca", function() vim.lsp.buf.code_action() end, { desc = "Code action" })
-keymap.set("n", "K", function() vim.lsp.buf.hover() end, { desc = "Hover documentation" })
 
 keymap.set("n", "<CR>", "G")
 keymap.set("n", "<BS>", "gg")

--- a/lua/config/lsp.lua
+++ b/lua/config/lsp.lua
@@ -3,6 +3,8 @@ local filetypes = require("config.lsp_filetypes")
 
 vim.diagnostic.config({
   float = { border = "rounded" },
+  severity_sort = true,
+  virtual_lines = { current_line = true },
 })
 
 vim.api.nvim_create_autocmd("LspAttach", {

--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -1,7 +1,3 @@
-vim.scriptencoding = "utf-8"
-vim.opt.encoding = "utf-8"
-vim.opt.fileencoding = "utf-8"
-
 vim.opt.title = true
 vim.opt.autoindent = true
 vim.opt.smarttab = true
@@ -62,7 +58,7 @@ vim.opt.tabstop = 2
 vim.opt.termguicolors = true
 vim.opt.textwidth = 80
 vim.opt.signcolumn = "yes"
-vim.opt.completeopt = { "menu", "menuone", "popup", "fuzzy", "nearest" }
+vim.opt.completeopt = { "menuone", "noselect", "popup", "fuzzy" }
 vim.opt.updatetime = 300
 vim.opt.updatecount = 0
 vim.opt.undofile = true
@@ -74,7 +70,7 @@ vim.opt.whichwrap = "b,h,l,s,<,>,[,],~"
 vim.opt.wildcharm = 26
 vim.opt.wildignore:append({ "*.o", "*.rej", "*.so", "*/node_modules/*" })
 vim.opt.wildmenu = true
-vim.opt.wildmode = "longest:full,full"
+vim.opt.wildmode = "noselect:lastused,full"
 vim.opt.writebackup = false
 
 vim.opt.cursorline = false
@@ -86,7 +82,7 @@ vim.opt.softtabstop = 2
 vim.opt.backspace = { "start", "eol", "indent" }
 vim.opt.hlsearch = true
 vim.opt.wrap = false
-vim.opt.wildoptions = "pum"
+vim.opt.wildoptions = { "pum", "fuzzy" }
 vim.opt.pumborder = "rounded"
 vim.opt.winborder = "rounded"
 

--- a/lua/config/plugins.lua
+++ b/lua/config/plugins.lua
@@ -60,7 +60,6 @@ return {
     end,
   },
 
-  { "tpope/vim-commentary", keys = { { "gc", mode = { "n", "v" } } } },
   {
     "nvim-lualine/lualine.nvim",
     dependencies = { "nvim-tree/nvim-web-devicons" },

--- a/tests/startup_spec.lua
+++ b/tests/startup_spec.lua
@@ -33,6 +33,12 @@ assert_mapping("<C-b>", "Find buffers")
 assert_mapping("fg", "FFF grep")
 assert_mapping("<leader>g", "FFF git files")
 assert_mapping("<leader>c", "FFF colors")
+assert_mapping("gc", "Toggle comment")
+assert_mapping("grx", "vim.lsp.codelens.run()")
+
+assert(vim.o.completeopt == "menuone,noselect,popup,fuzzy", "expected modern insert completion behavior")
+assert(vim.o.wildmode == "noselect:lastused,full", "expected non-selecting command-line completion")
+assert(vim.o.wildoptions == "pum,fuzzy", "expected fuzzy command-line completion")
 
 vim.api.nvim_exec_autocmds("UIEnter", {})
 assert(vim.g.colors_name == "lanciabones", "expected the configured colorscheme after UI startup")
@@ -54,5 +60,15 @@ assert(vim.fn.exists(":FFFPlusBuffers") == 2, "expected fff-plus commands after 
 vim.bo.filetype = "lua"
 assert(package.loaded["config.lsp"] ~= nil, "expected LSP config to load for a Lua buffer")
 assert(vim.lsp.config.lua_ls ~= nil, "expected lua_ls to remain configured after lazy loading")
+
+local diagnostic_config = vim.diagnostic.config()
+assert(diagnostic_config.severity_sort, "expected diagnostics to sort by severity")
+assert(
+  diagnostic_config.virtual_lines and diagnostic_config.virtual_lines.current_line,
+  "expected diagnostic virtual lines on the current line"
+)
+
+vim.cmd.edit("/tmp/nvim-config-startup-spec.tsx")
+assert(vim.bo.filetype == "typescriptreact", "expected Neovim's native TSX filetype")
 
 vim.cmd("quitall!")


### PR DESCRIPTION
Use native TSX and YAML filetype detection, modernize completion and diagnostic behavior, and rely on built-in LSP and comment mappings.

Remove redundant encoding settings and vim-commentary, fix the broken Linux finder fallback, and add startup regression coverage for the updated defaults.